### PR TITLE
コメントアウトなど

### DIFF
--- a/assembler.py
+++ b/assembler.py
@@ -1,5 +1,4 @@
 import sys
-import fileinput
 import re
 import argparse
 
@@ -9,14 +8,20 @@ def read_data(infile):
     コマンドライン引数の一番目で指定されたファイルから読み取り、一行ずつリストにして返す。
     コマンドライン引数が指定されなかった場合は、標準入力を読み取る。
     """
-    if not infile:
-        infile = []
+    try:
+        with open(infile, errors="ignore") as f:
+            data = [line.strip() for line in f.readlines()]
+            return data
+    except Exception as e:
+        if infile:
+            print(e)
     data = []
-    for line in fileinput.input(files=infile, encoding="utf-8"):
-        s = line.strip()
-        data.append(s)
-        if not s and fileinput.isstdin():
-            break # 標準入力のとき空行があったら終了
+    print("命令列を入力してください")
+    while True:
+        line = input().strip()
+        if not line:
+            break
+        data.append(line)
     return data
 
 
@@ -26,8 +31,6 @@ def preproc(line):
       引数は英数字以外の文字で分割され、前から順番にargsに入る。
       d(Rb)の形式のものは、d,Rbの順でargsに入る。
     """
-    if "//" in line:
-        line = line[:line.find("//")]
     head, *tail = re.findall(r"[a-zA-Z]+|[-+]?\d+", line)
     cmd = head.upper()
     args = []
@@ -112,7 +115,7 @@ def assemble(data):
             continue
         cmd, args = "", []
         try:
-            cmd, args = preproc(data[i])
+            cmd, args = preproc(line)
         except ValueError as e:
             print(str(i + 1) + "行目: 命令の引数が不正です", e, file=sys.stderr)
             exit(1)

--- a/assembler.py
+++ b/assembler.py
@@ -1,5 +1,5 @@
-import os
 import sys
+import fileinput
 
 
 def read_data():
@@ -7,14 +7,16 @@ def read_data():
     コマンドライン引数の一番目で指定されたファイルから読み取り、一行ずつリストにして返す。
     コマンドライン引数が指定されなかった場合は、usageを表示してプログラムを終了する。
     """
-    if len(sys.argv) < 2:
-        print("usage: python3 assembler.py input-file [output-file]", file=sys.stderr)
-        exit(1)
-    path_in = sys.argv[1]
-    fin = open(path_in)
-    s = [tmp.strip() for tmp in fin.readlines()]
-    fin.close()
-    return s
+    data = []
+    for line in fileinput.input(encoding="utf-8"):
+        s = line.strip()
+        if not s:
+            if fileinput.isstdin():
+                break
+            else:
+                continue
+        data.append(s)
+    return data
 
 
 def preproc(line):
@@ -238,7 +240,10 @@ def write_result(result):
             print("\t" + str(i) + " : " + result[i] + ";")
         print("END;")
 
+def main():
+    data = read_data()
+    result = assemble(data)
+    write_result(result)
 
-data = read_data()
-result = assemble(data)
-write_result(result)
+if __name__ == "__main__":
+    main()

--- a/assembler.py
+++ b/assembler.py
@@ -1,20 +1,21 @@
-import os
 import sys
+import fileinput
 
 
 def read_data():
     """
     コマンドライン引数の一番目で指定されたファイルから読み取り、一行ずつリストにして返す。
-    コマンドライン引数が指定されなかった場合は、usageを表示してプログラムを終了する。
+    コマンドライン引数が指定されなかった場合は、標準入力を読み取る
     """
-    if len(sys.argv) < 2:
-        print("usage: python3 assembler.py input-file [output-file]", file=sys.stderr)
-        exit(1)
-    path_in = sys.argv[1]
-    fin = open(path_in)
-    s = [tmp.strip() for tmp in fin.readlines()]
-    fin.close()
-    return s
+    data = []
+    for line in fileinput.input(encoding="utf-8"):
+        s = line.strip()
+        if not s:
+            if fileinput.isstdin():
+                break # 標準入力のとき空行があったら終了
+        else:
+            data.append(s)
+    return data
 
 
 def preproc(line):
@@ -238,7 +239,10 @@ def write_result(result):
             print("\t" + str(i) + " : " + result[i] + ";")
         print("END;")
 
+def main():
+    data = read_data()
+    result = assemble(data)
+    write_result(result)
 
-data = read_data()
-result = assemble(data)
-write_result(result)
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 変更点

- 出力のアドレスとデータの表記法（基数）を選べるようにした
- コンマを使わずにスペース区切りなどで書かれたプログラムも読めるようにした
- コメントアウト `//` 以降を無視するようにした
- 値として単体で置かれた数字を読めるようにした
- 標準入力から入力できるようにした

## 使用方法

```
> python assembler.py --help
usage: assembler.py [-h] [-d [DEPTH]] [-ar [{2,10,16}]] [-dr [{2,10,16}]] [-f [FILL]] [input] [output]

SIMPLEアセンブラ

positional arguments:
  input                 入力ファイル (デフォルト: 標準入力)
  output                出力ファイル (デフォルト: 標準出力)

options:
  -h, --help            show this help message and exit
  -d [DEPTH], --depth [DEPTH]
                        ワード数 (デフォルト: 4096)
  -ar [{2,10,16}], --address_radix [{2,10,16}]
                        アドレスの基数 (デフォルト: 10)
  -dr [{2,10,16}], --data_radix [{2,10,16}]
                        データの基数 (デフォルト: 10)
  -f [FILL], --fill [FILL]
                        空きメモリに埋める数 (デフォルト: 0)
```

simple_sample の各プログラムをこのアセンブラに入れたところ, 置かれていたmif ファイルと同じものができたことを確認しました.  
プルリクエストを初めて使うので変なことをしていたら申し訳ありません